### PR TITLE
calc: Remove calc from dependencies

### DIFF
--- a/BPMRFFEApp/src/Makefile
+++ b/BPMRFFEApp/src/Makefile
@@ -16,11 +16,8 @@ BPMRFFE_LIBS += asyn
 BPMRFFE_DBD += asyn.dbd
 BPMRFFE_DBD += drvAsynIPPort.dbd
 
-BPMRFFE_LIBS += calc
-BPMRFFE_DBD += calcSupport.dbd
-
 BPMRFFE_LIBS += stream
-BPMRFFE_DBD += stream.dbd
+BPMRFFE_DBD += stream-base.dbd
 
 BPMRFFE_LIBS += autosave
 BPMRFFE_DBD += asSupport.dbd

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -25,7 +25,6 @@
 # Variables and paths to dependent modules:
 MODULES = /opt/epics/modules
 ASYN = $(MODULES)/asyn
-CALC = $(MODULES)/calc
 STREAM = $(MODULES)/StreamDevice
 AUTOSAVE = $(MODULES)/autosave
 


### PR DESCRIPTION
Despite StreamDevice being built with Calc, there is no need to include it as a dependency for the IOC [if we use `stream-base.dbd` instead of `stream.dbd`][1].

[1]: https://epics.anl.gov/tech-talk/2023/msg00951.php

Reverts: 32a6e052f3b14f637ead2f69740c904ff5d3b037