### PR TITLE
autosave: fix mismatching save and restore filenames

### DIFF
--- a/iocBoot/iocBPMRFFEApp/st.cmd
+++ b/iocBoot/iocBPMRFFEApp/st.cmd
@@ -35,4 +35,4 @@ cd "${TOP}/iocBoot/${IOC}"
 iocInit
 
 create_monitor_set("bpmrffe.req", 30, "P=$(P), R=$(R)")
-set_savefile_name("bpmrffe.req", "$(P)$(R).sav")
+set_savefile_name("bpmrffe.req", "$(P)$(R)_settings.sav")


### PR DESCRIPTION
Any saved files from previous versions need to be (manually) renamed to contain `_settings` if we are willing to have them restored.

Will we script that (elsewhere) or is it reasonable to lose them?