### PR TITLE
docker: upgrade to epics-in-docker v0.3.0.

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -23,13 +23,12 @@
 # the CONFIG_SITE file.
 
 # Variables and paths to dependent modules:
-MODULES = /opt/epics/modules
-ASYN = $(MODULES)/asyn
-STREAM = $(MODULES)/StreamDevice
-AUTOSAVE = $(MODULES)/autosave
+ASYN =
+STREAM =
+AUTOSAVE =
 
 # EPICS_BASE should appear last so earlier modules can override stuff:
-EPICS_BASE = /opt/epics/base
+EPICS_BASE =
 
 # These allow developers to override the RELEASE variable settings
 # without having to modify the configure/RELEASE file itself.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       context: ./
       dockerfile: docker/Dockerfile
+      target: static-link
       labels:
         org.opencontainers.image.source: https://github.com/lnls-dig/rffe-epics-ioc
       args:


### PR DESCRIPTION
Since `RELEASE` is configured during the build, there is not need to define the paths in this repository. Thus, to avoid definition misinterpretation, all paths have been left blank. All dependend modules still documented in the RELEASE file, as it is a standard place to look for dependencies.

Target build stage is defined explicitly, so that it is consistent with other IOCs and the epics-in-docker guidelines.