### PR TITLE
deploy: use unless-stopped restart policy.

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     rffe-ioc: &base
         image: ghcr.io/lnls-dig/rffe-epics-ioc
         network_mode: host
+        restart: unless-stopped
         volumes:
           - type: bind
             source: /var/opt/rffe-epics-ioc


### PR DESCRIPTION
This should allow Docker Compose to restart a stopped container when udev has not triggered `docker-compose up` in the appropriate time, which is after Docker daemon has started. This removes the need to add the Docker service as a dependency for starting up other modules in bpm-app.

Unless-stopped policy has been chosen instead of "always", so that we can still have it manually stopped without removing it.