### PR TITLE
ci: add image build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build image
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build_and_push:
+    permissions:
+      packages: write
+      contents: read
+    uses: cnpem/epics-in-docker/.github/workflows/ioc-images.yml@main


### PR DESCRIPTION
The intention here is to try out a "bare-bones" CI build for building and pushing builds on tagging (maybe should add a `TAG` env var as well for those workflows where it matters).

We can add it as an example in epics-in-docker.