### PR TITLE
deploy: use anchor to reuse common env variables.

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,147 +8,126 @@ services:
           - type: bind
             source: /var/opt/rffe-epics-ioc
             target: /var/opt/rffe-epics-ioc
+        environment: &env
+            CRATE_NUMBER: ${CRATE_NUMBER}
+            RFFE_BASE_IP_ADDRESS: 192.168.2.190
     rffe-ioc-1:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 1
     rffe-ioc-2:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 2
     rffe-ioc-3:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 3
     rffe-ioc-4:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 4
     rffe-ioc-5:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 5
     rffe-ioc-6:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 6
     rffe-ioc-7:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 7
     rffe-ioc-8:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 8
     rffe-ioc-9:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 9
     rffe-ioc-10:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 10
     rffe-ioc-11:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 11
     rffe-ioc-12:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 12
     rffe-ioc-13:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 13
     rffe-ioc-14:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 14
     rffe-ioc-15:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 15
     rffe-ioc-16:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 16
     rffe-ioc-17:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 17
     rffe-ioc-18:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 18
     rffe-ioc-19:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 19
     rffe-ioc-20:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 20
     rffe-ioc-21:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 21
     rffe-ioc-22:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 22
     rffe-ioc-23:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 23
     rffe-ioc-24:
         <<: *base
         environment:
-            CRATE_NUMBER: ${CRATE_NUMBER}
-            RFFE_BASE_IP_ADDRESS: 192.168.2.190
+            <<: *env
             BPM_NUMBER: 24


### PR DESCRIPTION
Reduce the amount of information replicated in the compose file. Merging the reusable mappings must be done explicitly, using [YAML merge feature][1], so it is not a limitation of the docker-compose we use in deploy.

[1]: https://yaml.org/type/merge.html

Fixes: 655c72f ("deploy: Add docker-compose to launch IOCs")