### PR TITLE
deploy: provide a systemd unit managing containers.

### DIFF
--- a/deploy/rffe-ioc@.service
+++ b/deploy/rffe-ioc@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=RFFE EPICS IOC %i
+
+[Service]
+User=iocs
+
+MemoryAccounting=yes
+
+WorkingDirectory=/opt/rffe-epics-ioc
+ExecStart=/bin/sh -c "CRATE_NUMBER=$(/opt/afc-epics-ioc/iocBoot/iocutca/getCrate.sh) podman-compose up rffe-ioc-%i"
+ExecStop=/usr/bin/podman-compose stop --timeout=0 rffe-ioc-%i


### PR DESCRIPTION
When attempting to run in a podman namespace through a udev-triggered script, filesystem mounting does not work out-of-the-box. When configured with overlayfs, a permission denied occurs when remouting `containers/storage/overlay/` with flags 0x40000. Similar issues happen with vfs, and probably other filesystems.

Launching the container under systemd does not provoke such not understood issues. Let's provide a systemd-unit to be started by udev when the IOC must be run. This is similar to the AFC EPICS IOC deploy, also making services management uniform.

During stop, a timeout of zero is provided to use SIGKILL right away, since the SIGTERM signal does not reach the procServ process and its childs for a yet unknown reason.