### PR TITLE
autosave: drop autosave subdirectory in save path

### DIFF
--- a/iocBoot/iocBPMRFFEApp/save_restore.cmd
+++ b/iocBoot/iocBPMRFFEApp/save_restore.cmd
@@ -9,7 +9,7 @@ save_restoreSet_DatedBackupFiles(1)
 save_restoreSet_NumSeqFiles(3)
 save_restoreSet_SeqPeriodInSeconds(300)
 
-set_savefile_path("/var/opt/rffe-epics-ioc", "autosave")
+set_savefile_path("/var/opt/rffe-epics-ioc", "")
 
 set_pass0_restoreFile("$(P)$(R)_settings.sav")
 set_pass1_restoreFile("$(P)$(R)_settings.sav")


### PR DESCRIPTION
This subdirectory was initially thought as a way to have a proper namespace for autosave files among runtime variable data handled by the IOC. It turns out though that no other data is actually generated. Drop such namespace, as already expected by deploy scripts [1].

[1] https://github.com/lnls-dig/bpm-app/commit/e6670fe6382a2cb8b91da2849194ca84d6278a12