### PR TITLE
service: fix asCa connection issues.

### DIFF
--- a/service/rffe-ioc@.service
+++ b/service/rffe-ioc@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=RFFE EPICS IOC %i
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=iocs


### PR DESCRIPTION
The Access Security configuration for this IOC uses a PV from the BPM IOC [1] to determine whether certain writes are allowed. When rebooting the IOC server, we occasionally hit a situation where the connection to the BPM PV never completed successfully, causing writes to be disabled for the life of the IOC.

This issue was reported and investigated in tech-talk [2], and we applied the suggested solution, following the example service [3].

[1] https://github.com/lnls-dig/afc-epics-ioc
[2] https://epics.anl.gov/tech-talk/2026/msg00340.php
[3] https://github.com/NSLS2/systemd-softioc/blob/master/softioc-example.service

---

@gustavosr8